### PR TITLE
fix: improve pre-commit hooks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,6 +18,6 @@ max_line_length = 119
 [Makefile]
 indent_style = tab
 
-[*.yml]
+[{*.yml,*.yaml}]
 indent_size = 2
 quote_type = single

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,11 @@ default_install_hook_types:
   - commit-msg
 
 repos:
+  - repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
+    rev: v0.8.0
+    hooks:
+      - id: pre-commit-update
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.11
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,14 +4,14 @@ default_install_hook_types:
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.8
+    rev: v0.12.11
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix]
       - id: ruff-format
 
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.0.0
+    rev: v4.2.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]


### PR DESCRIPTION
## Description
* automatically update pre-commit
* change ruff to ruff-check (new name)
* update ruff-pre-commit
* update conventional-pre-commit