### PR TITLE
fix: remove python 3.8 and 3.9 support

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = py{38,39,310,311,312,313}-dj{2,3,4,5}
+envlist = py{310,311,312,313}-dj{2,3,4,5}
 
 [testenv]
 usedevelop = true
 deps =
-    py{38,39,310,311,312,313}: -rrequirements/requirements-dev.txt
+    py{310,311,312,313}: -rrequirements/requirements-dev.txt
     dj{2}: -rrequirements/requirements-dj2.txt
     dj{3}: -rrequirements/requirements-dj3.txt
     dj{4}: -rrequirements/requirements-dj4.txt
@@ -13,8 +13,6 @@ commands = pytest
 
 [gh-actions]
 python =
-    3.8: py38
-    3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312


### PR DESCRIPTION
## Description
remove python 3.8 (EOL) and 3.9 (EOL in one month) support